### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 
 **NOTE**: This is an unofficial implementation of MCP Server for ZapCap.
 
+<a href="https://glama.ai/mcp/servers/@bogdan01m/zapcap-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bogdan01m/zapcap-mcp-server/badge" alt="zapcap-mcp-server MCP server" />
+</a>
+
 An MCP (Model Context Protocol) server that provides tools for uploading videos, creating processing tasks, and monitoring their progress through the [ZapCap API](https://zapcap.ai/).
 
 ## Requirements
 
 - uv 
 - ZapCap API key
-
 
 You can install uv from here: https://docs.astral.sh/uv/
 


### PR DESCRIPTION
This PR adds a badge for the [zapcap-mcp-server](https://glama.ai/mcp/servers/@bogdan01m/zapcap-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bogdan01m/zapcap-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bogdan01m/zapcap-mcp-server/badge" alt="zapcap-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.